### PR TITLE
README.md: Tiny wording fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Gitlanding helps you create a beautiful landing page for your GitHub projects in
 -   Import some [`gitlanding` components](https://www.gitlanding.dev/storybook/).
 -   Auto deploy with [GitHub Actions](https://github.com/features/actions), host it using [GitHub page](https://pages.github.com/)!
 
-Don't worry, you will be guided every step of the way with [specific instruction for **MacOS**, **Widows** and **Linux**](https://docs.gitlanding.dev/#step-by-step-guide).  
+Don't worry, you will be guided every step of the way with [specific instruction for **MacOS**, **Widows** and **GNU/Linux**](https://docs.gitlanding.dev/#step-by-step-guide).  
 Setting up a GitLanding page is also a great practical introduction to [GitHub Actions](https://github.com/features/actions) and [GitHub page](https://pages.github.com/).
 
 # Motivation


### PR DESCRIPTION
When mentioning the operating system, "GNU/Linux" is better.

Disclaimer: I'm a colleague of @garronej :)